### PR TITLE
Fix 0-Agent Interactions.py

### DIFF
--- a/pages/0-Agent Interactions.py
+++ b/pages/0-Agent Interactions.py
@@ -72,6 +72,8 @@ if mode == "Chains":
             )
     else:
         single_step = False
+        from_step = 1
+        all_responses = False
     args = chain_selection()
     args["conversation_name"] = st.session_state["conversation"]
     chain_name = args["chain"] if "chain" in args else ""


### PR DESCRIPTION
Define all_responses and  from_step variables if the user don't want to use any advanced option for running chains otherwise undefined error occur when running chains