### PR TITLE
Bump SDK verision and Fix: Ensure unique widget keys in build_args method to avoid DuplicateWidgetID error

### DIFF
--- a/components/selectors.py
+++ b/components/selectors.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import os
+import uuid
 import logging
 import html
 import re
@@ -120,7 +121,7 @@ class AGiXTSelectors:
             self.skip_args.append("input")
         return {
             arg: st.text_area(
-                arg, value=prompt.get(arg, ""), key=f"{arg}_{step_number}"
+                arg, value=prompt.get(arg, ""), key=f"{arg}_{step_number}_{uuid.uuid4()}"
             )
             for arg in args
             if arg not in self.skip_args

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 streamlit
 streamlit_js_eval
-agixtsdk==0.0.55
+agixtsdk==0.0.71
 python-dotenv==1.0.0
 urllib3==2.2.2
 requests


### PR DESCRIPTION
This bumps the SDK to the current latest, and this fixes an issue when modifying a chain 
